### PR TITLE
Update container version; Increases resource alloc

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -9,8 +9,8 @@ params {
 process {
   withName: genomechronicler {
     container = "lifebitai/genomechronicler:pgp-uk-65df2a9"
-    cpus = 32
-    memory = 240.GB
+    cpus = 8
+    memory = 16.GB
     maxForks = 2
   }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,6 +8,9 @@ params {
 
 process {
   withName: genomechronicler {
-    container = "lifebitai/genomechronicler:pgp-uk-java13-deduped-paths"
+    container = "lifebitai/genomechronicler:pgp-uk-65df2a9"
+    cpus = 32
+    memory = 240.GB
+    maxForks = 2
   }
 }


### PR DESCRIPTION
This PR updates the docker container used for GenomeChronickler - the updated tag `:pgp-uk-65df2a9` reflects Afonso's latest changes in GenomeChronicler. Also, more resources are allocated as the tests were ran for low coverage example data and for PGP the standard coverage is 30x.